### PR TITLE
Fix exception handling in create_config_service (#2423)

### DIFF
--- a/patroni/dcs/kubernetes.py
+++ b/patroni/dcs/kubernetes.py
@@ -890,7 +890,8 @@ class Kubernetes(AbstractDCS):
             if not self._api.create_namespaced_service(self._namespace, body):
                 return
         except Exception as e:
-            if not isinstance(e, k8s_client.rest.ApiException) or e.status != 409:  # Service already exists
+            # 409 - service already exists, 403 - creation forbidden
+            if not isinstance(e, k8s_client.rest.ApiException) or e.status not in (409, 403):
                 return logger.exception('create_config_service failed')
         self._should_create_config_service = False
 

--- a/tests/test_kubernetes.py
+++ b/tests/test_kubernetes.py
@@ -290,11 +290,32 @@ class TestKubernetesEndpoints(BaseTestKubernetes):
     @patch.object(k8s_client.CoreV1Api, 'patch_namespaced_pod', mock_namespaced_kind, create=True)
     @patch.object(k8s_client.CoreV1Api, 'create_namespaced_endpoints', mock_namespaced_kind, create=True)
     @patch.object(k8s_client.CoreV1Api, 'create_namespaced_service',
-                  Mock(side_effect=[True, False, k8s_client.rest.ApiException(500, '')]), create=True)
-    def test__create_config_service(self):
+                  Mock(side_effect=[True,
+                                    False,
+                                    k8s_client.rest.ApiException(409, ''),
+                                    k8s_client.rest.ApiException(403, ''),
+                                    k8s_client.rest.ApiException(500, ''),
+                                    Exception("Unexpected")
+                                    ]), create=True)
+    @patch('patroni.dcs.kubernetes.logger.exception')
+    def test__create_config_service(self, mock_logger_exception):
         self.assertIsNotNone(self.k.patch_or_create_config({'foo': 'bar'}))
         self.assertIsNotNone(self.k.patch_or_create_config({'foo': 'bar'}))
+
+        self.k.patch_or_create_config({'foo': 'bar'})
+        mock_logger_exception.assert_not_called()
+
+        self.k.patch_or_create_config({'foo': 'bar'})
+        mock_logger_exception.assert_not_called()
+
+        self.k.patch_or_create_config({'foo': 'bar'})
+        mock_logger_exception.assert_called_once()
+        self.assertEqual(('create_config_service failed',), mock_logger_exception.call_args[0])
+        mock_logger_exception.reset_mock()
+
         self.k.touch_member({'state': 'running', 'role': 'replica'})
+        mock_logger_exception.assert_called_once()
+        self.assertEqual(('create_config_service failed',), mock_logger_exception.call_args[0])
 
 
 class TestCacheBuilder(BaseTestKubernetes):

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -35,7 +35,7 @@ def mock_ioctl(fd, op, arg=None, mutate_flag=False):
     sys.stderr.write("Ioctl %d %d %r\n" % (fd, op, arg))
     if op == linuxwd.WDIOC_GETSUPPORT:
         sys.stderr.write("Get support\n")
-        assert(mutate_flag is True)
+        assert (mutate_flag is True)
         arg.options = sum(map(linuxwd.WDIOF.get, ['SETTIMEOUT', 'KEEPALIVEPING']))
         arg.identity = (ctypes.c_ubyte*32)(*map(ord, 'Mock Watchdog'))
     elif op == linuxwd.WDIOC_GETTIMEOUT:


### PR DESCRIPTION
Cherry picking fix for creating Kubernetes Service from [3dcdb16](https://github.com/zalando/patroni/commit/3dcdb16d2a57e56813e65f5c7727d49cabb41bee) `upstream/patroni`.