### PR TITLE
WIP: prevent location-only pod updates

### DIFF
--- a/patroni/validator.py
+++ b/patroni/validator.py
@@ -1124,6 +1124,7 @@ schema = Schema({
             Optional("ports"): [{"name": str, "port": IntValidator(max=65535, expected_type=int, raise_assert=True)}],
             Optional("cacert"): str,
             Optional("retriable_http_codes"): Or(int, [int]),
+            Optional('prevent_xlog_position_only_pod_updates'): bool
         },
     }),
     Optional("citus"): {


### PR DESCRIPTION
Prevent annotation updates when the only update is the pod xlog location.

This reduces the load on the K8s API for the replicas, as we don't have to update the pod every loop_wait interval.