### PR TITLE
Add --progress --debug to pg_rewind

### DIFF
--- a/patroni/postgresql/rewind.py
+++ b/patroni/postgresql/rewind.py
@@ -45,6 +45,14 @@ class Rewind(object):
         return bool(self._postgresql.config.get('use_pg_rewind'))
 
     @property
+    def enable_progress_logging(self) -> bool:
+        return bool(self._postgresql.config.get('pg_rewind_log_progress'))
+
+    @property
+    def enable_debug_logging(self) -> bool:
+        return bool(self._postgresql.config.get('pg_rewind_log_debug'))
+
+    @property
     def can_rewind(self) -> bool:
         """ check if pg_rewind executable is there and that pg_controldata indicates
             we have either wal_log_hints or checksums turned on
@@ -445,6 +453,12 @@ class Rewind(object):
             if self._postgresql.major_version >= 150000 and\
                     self._postgresql.config.config_dir != self._postgresql.data_dir:
                 cmd.append('--config-file={0}'.format(self._postgresql.config.postgresql_conf))
+
+        if self.enable_progress_logging:
+            cmd.append('--progress')
+
+        if self.enable_debug_logging:
+            cmd.append('--debug')
 
         cmd.extend(['-D', self._postgresql.data_dir, '--source-server', dsn])
 

--- a/patroni/validator.py
+++ b/patroni/validator.py
@@ -1048,6 +1048,8 @@ schema = Schema({
                     Optional("max_worker_processes"): IntValidator(0, 262143, raise_assert=True),
                 },
                 Optional("use_pg_rewind"): bool,
+                Optional("pg_rewind_log_progress"): bool,
+                Optional("pg_rewind_log_debug"): bool,
                 Optional("pg_hba"): [str],
                 Optional("pg_ident"): [str],
                 Optional("pg_ctl_timeout"): IntValidator(min=0, raise_assert=True),
@@ -1168,7 +1170,9 @@ schema = Schema({
         Optional("pg_hba"): [str],
         Optional("pg_ident"): [str],
         Optional("pg_ctl_timeout"): IntValidator(min=0, raise_assert=True),
-        Optional("use_pg_rewind"): bool
+        Optional("use_pg_rewind"): bool,
+        Optional("pg_rewind_log_progress"): bool,
+        Optional("pg_rewind_log_debug"): bool,
     },
     Optional("watchdog"): {
         Optional("mode"): validate_watchdog_mode,


### PR DESCRIPTION
This will help us find the source of OOMs, as pg_rewind shows both its actions (i.e. "reading source file list"), the amount of files to copy, but also a filemap (with debug) with the actions it needs to perform.

Fixes ORC-33