### PR TITLE
Update ydiff requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ python-dateutil
 pysyncobj>=0.3.8
 cryptography>=1.4
 psutil>=2.0.0
-ydiff>=1.2.0
+ydiff>=1.2.0,<1.4.0
 python-json-logger>=2.0.2


### PR DESCRIPTION
ydiff 1.4.0, 1.4.1 and 1.4.2 break patronictl edit-config. It would be resolved once we rebase on top of 4.0.5 or higher.