### PR TITLE
Optionally calculate LSNs from live members

### DIFF
--- a/docs/patronictl.rst
+++ b/docs/patronictl.rst
@@ -648,6 +648,7 @@ Synopsis
       [ --group CITUS_GROUP ]
       [ { -e | --extended } ]
       [ { -t | --timestamp } ]
+      [ --live ]
       [ { -f | --format } { pretty | tsv | json | yaml } ]
       [ { -W | { -w | --watch } TIME } ]
 
@@ -657,6 +658,10 @@ Description
 """""""""""
 
 ``patronictl list`` shows information about Patroni cluster and its members.
+
+Passing ``--live`` instructs ``patronictl`` to query the Patroni REST API with ``/cluster?live=1`` so that replica LSN
+and lag metrics reflect the latest responses from each member. Older Patroni nodes ignore this query parameter, and
+newer versions fall back to the DCS snapshot automatically if live data is unavailable.
 
 The following information is included in the output:
 
@@ -704,6 +709,10 @@ The following information is included in the output:
 
 ``Replay Lag``
     Replication lag between the ``Replay LSN`` position of the member and its upstream in in MB.
+
+``LSN Source``
+    Shows whether the LSN-related metrics for the replica were gathered from a live REST poll (``live``) or from the
+    DCS (``dcs``). This column is shown only when ``--live`` is used.
 
 Besides that, the following information may be included in the output:
 

--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -423,7 +423,10 @@ The ``patroni_postgres_state`` metric provides a numeric representation of the c
 Cluster status endpoints
 ------------------------
 
-- The ``GET /cluster`` endpoint generates a JSON document describing the current cluster topology and state:
+- The ``GET /cluster`` endpoint generates a JSON document describing the current cluster topology and state. It also
+  accepts an optional ``?live=1`` (or any true-ish value) query parameter, which hints that callers prefer live member
+  statistics, as opposed to reading it from the DCS. At present the response is identical to ``/cluster`` without the
+  flag, but the parameter is reserved so future versions can return fresher lag information without breaking compatibility.
 
 .. code-block:: bash
 

--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -424,9 +424,10 @@ Cluster status endpoints
 ------------------------
 
 - The ``GET /cluster`` endpoint generates a JSON document describing the current cluster topology and state. It also
-  accepts an optional ``?live=1`` (or any true-ish value) query parameter, which hints that callers prefer live member
-  statistics, as opposed to reading it from the DCS. At present the response is identical to ``/cluster`` without the
-  flag, but the parameter is reserved so future versions can return fresher lag information without breaking compatibility.
+  accepts an optional ``?live=1`` (or any true-ish value) query parameter, which tells Patroni to poll each member for
+  live lag information (falling back to the DCS for members that do not respond). Each replica entry carries an
+  ``lsn_source`` flag showing whether its LSN-derived metrics were pulled live or from the DCS. Clusters with no replicas skip
+  the poll automatically.
 
 .. code-block:: bash
 

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -542,8 +542,10 @@ class RestApiHandler(BaseHTTPRequestHandler):
         Write an HTTP response with JSON content based on the output of :func:`~patroni.utils.cluster_as_json`, with
         HTTP status ``200`` and the JSON representation of the cluster topology.
         """
+        live_requested = parse_bool(self.path_query.get('live', [None])[0]) or False
+        if live_requested:
+            logger.debug("/cluster requested with live view (future behavior not yet enabled)")
         cluster = self.server.patroni.dcs.get_cluster()
-
         response = cluster_as_json(cluster)
         response['scope'] = self.server.patroni.postgresql.scope
         self._write_json_response(200, response)

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -31,7 +31,7 @@ from .__main__ import Patroni
 from .dcs import Cluster
 from .exceptions import PostgresConnectionException, PostgresException
 from .postgresql.misc import postgres_version_to_int, PostgresqlRole, PostgresqlState
-from .utils import cluster_as_json, deep_compare, enable_keepalive, parse_bool, \
+from .utils import LiveMemberLSNs, cluster_as_json, deep_compare, enable_keepalive, parse_bool, \
     parse_int, patch_config, Retry, RetryFailedError, split_host_port, tzutc, uri
 
 logger = logging.getLogger(__name__)
@@ -549,6 +549,44 @@ class RestApiHandler(BaseHTTPRequestHandler):
         response = cluster_as_json(cluster)
         response['scope'] = self.server.patroni.postgresql.scope
         self._write_json_response(200, response)
+
+    @staticmethod
+    def _status_to_live_lsn(status: Dict[str, Any]) -> LiveMemberLSNs:
+        wal = status.get('wal') or status.get('xlog') or {}
+        location = parse_int(wal.get('location'))
+        receive = parse_int(wal.get('received_location'))
+        replay = parse_int(wal.get('replayed_location'))
+        return LiveMemberLSNs(location, receive, replay)
+
+    def get_live_member_lsns(self, cluster: Cluster) -> Dict[str, LiveMemberLSNs]:
+        """Collect live WAL metrics for local and remote members."""
+        live_map: Dict[str, LiveMemberLSNs] = {}
+        local_name = self.server.patroni.postgresql.name
+
+        try:
+            live_map[local_name] = self._status_to_live_lsn(self.get_postgresql_status(True))
+        except Exception as e:  # pragma: no cover - defensive, tested via mocks
+            logger.debug("Failed to collect local live status: %s", e)
+
+        members = [m for m in cluster.members if m.name != local_name and m.api_url]
+        if not members:
+            return live_map
+
+        try:
+            statuses = self.server.patroni.ha.fetch_nodes_statuses(members)
+        except Exception as e:  # pragma: no cover - defensive; exercised via unit tests
+            logger.debug("Failed to collect remote live statuses: %s", e)
+            return live_map
+
+        for status in statuses:
+            member_name = status.member and status.member.name
+            if not member_name:
+                continue
+            if status.reachable and status.data:
+                live_map[member_name] = self._status_to_live_lsn(status.data)
+            else:
+                live_map.setdefault(member_name, LiveMemberLSNs())
+        return live_map
 
     def do_GET_history(self) -> None:
         """Handle a ``GET`` request to ``/history`` path.

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -31,8 +31,8 @@ from .__main__ import Patroni
 from .dcs import Cluster
 from .exceptions import PostgresConnectionException, PostgresException
 from .postgresql.misc import postgres_version_to_int, PostgresqlRole, PostgresqlState
-from .utils import LiveMemberLSNs, cluster_as_json, deep_compare, enable_keepalive, parse_bool, \
-    parse_int, patch_config, Retry, RetryFailedError, split_host_port, tzutc, uri
+from .utils import cluster_as_json, deep_compare, enable_keepalive, LiveMemberLSNs, \
+    parse_bool, parse_int, patch_config, Retry, RetryFailedError, split_host_port, tzutc, uri
 
 logger = logging.getLogger(__name__)
 
@@ -557,7 +557,7 @@ class RestApiHandler(BaseHTTPRequestHandler):
 
     @staticmethod
     def _status_to_live_lsn(status: Dict[str, Any]) -> LiveMemberLSNs:
-        wal = status.get('wal') or status.get('xlog') or {}
+        wal: Dict[str, Any] = status.get('wal') or status.get('xlog') or {}
         receive = parse_int(wal.get('received_location'))
         replay = parse_int(wal.get('replayed_location'))
         location = parse_int(wal.get('location')) or replay or receive

--- a/patroni/api.py
+++ b/patroni/api.py
@@ -543,19 +543,24 @@ class RestApiHandler(BaseHTTPRequestHandler):
         HTTP status ``200`` and the JSON representation of the cluster topology.
         """
         live_requested = parse_bool(self.path_query.get('live', [None])[0]) or False
-        if live_requested:
-            logger.debug("/cluster requested with live view (future behavior not yet enabled)")
         cluster = self.server.patroni.dcs.get_cluster()
-        response = cluster_as_json(cluster)
+        live_map: Optional[Dict[str, LiveMemberLSNs]] = None
+        if live_requested:
+            if len(cluster.members) > 1:
+                live_map = self.get_live_member_lsns(cluster)
+            else:
+                logger.debug("/cluster live view skipped: single-member cluster")
+
+        response = cluster_as_json(cluster, live_map)
         response['scope'] = self.server.patroni.postgresql.scope
         self._write_json_response(200, response)
 
     @staticmethod
     def _status_to_live_lsn(status: Dict[str, Any]) -> LiveMemberLSNs:
         wal = status.get('wal') or status.get('xlog') or {}
-        location = parse_int(wal.get('location'))
         receive = parse_int(wal.get('received_location'))
         replay = parse_int(wal.get('replayed_location'))
+        location = parse_int(wal.get('location')) or replay or receive
         return LiveMemberLSNs(location, receive, replay)
 
     def get_live_member_lsns(self, cluster: Cluster) -> Dict[str, LiveMemberLSNs]:
@@ -564,7 +569,9 @@ class RestApiHandler(BaseHTTPRequestHandler):
         local_name = self.server.patroni.postgresql.name
 
         try:
-            live_map[local_name] = self._status_to_live_lsn(self.get_postgresql_status(True))
+            local_status = self._status_to_live_lsn(self.get_postgresql_status(True))
+            if any((local_status.lsn, local_status.receive_lsn, local_status.replay_lsn)):
+                live_map[local_name] = local_status
         except Exception as e:  # pragma: no cover - defensive, tested via mocks
             logger.debug("Failed to collect local live status: %s", e)
 
@@ -583,9 +590,9 @@ class RestApiHandler(BaseHTTPRequestHandler):
             if not member_name:
                 continue
             if status.reachable and status.data:
-                live_map[member_name] = self._status_to_live_lsn(status.data)
-            else:
-                live_map.setdefault(member_name, LiveMemberLSNs())
+                converted = self._status_to_live_lsn(status.data)
+                if any((converted.lsn, converted.receive_lsn, converted.replay_lsn)):
+                    live_map[member_name] = converted
         return live_map
 
     def do_GET_history(self) -> None:

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -65,10 +65,10 @@ from . import global_config
 from .config import Config
 from .dcs import AbstractDCS, Cluster, get_dcs as _get_dcs, Leader, Member
 from .exceptions import PatroniException
-from .postgresql.misc import postgres_version_to_int, PostgresqlRole, PostgresqlState
+from .postgresql.misc import parse_lsn, postgres_version_to_int, PostgresqlRole, PostgresqlState
 from .postgresql.mpp import get_mpp
 from .request import PatroniRequest
-from .utils import cluster_as_json, patch_config, polling_loop
+from .utils import LiveMemberLSNs, cluster_as_json, patch_config, polling_loop
 from .version import __version__
 
 CONFIG_DIR_PATH = click.get_app_dir('patroni')
@@ -417,6 +417,46 @@ def request_patroni(member: Member, method: str = 'GET',
     if not request_executor:
         request_executor = ctx.obj['__request_patroni'] = PatroniRequest(_get_configuration())
     return request_executor(member, method, endpoint, data)
+
+
+def _parse_lsn_value(value: Any) -> Optional[int]:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        value = value.strip()
+        if not value or value.lower() == 'unknown':
+            return None
+        try:
+            return parse_lsn(value)
+        except Exception:
+            logging.debug('Failed to parse LSN value "%s"', value)
+    return None
+
+
+def fetch_live_status(cluster: Cluster, live_requested: bool) -> Optional[Dict[str, LiveMemberLSNs]]:
+    if not live_requested:
+        return None
+    for member in get_all_members_leader_first(cluster):
+        try:
+            response = request_patroni(member, endpoint='cluster?live=1')
+            if getattr(response, 'status', 0) >= 400:
+                logging.debug('Live /cluster request to %s returned status %s',
+                              member.name, getattr(response, 'status', None))
+                continue
+            payload = json.loads(response.data.decode('utf-8'))
+            live_map: Dict[str, LiveMemberLSNs] = {}
+            for entry in payload.get('members', []):
+                metrics = LiveMemberLSNs(
+                    _parse_lsn_value(entry.get('lsn')),
+                    _parse_lsn_value(entry.get('receive_lsn')),
+                    _parse_lsn_value(entry.get('replay_lsn')))
+                if any((metrics.lsn, metrics.receive_lsn, metrics.replay_lsn)):
+                    live_map[entry.get('name')] = metrics
+            if live_map:
+                return live_map
+        except Exception as e:
+            logging.debug('Failed to fetch live /cluster view from %s: %s', member.name, e)
+    return None
 
 
 def print_output(columns: Optional[List[str]], rows: List[List[Any]], alignment: Optional[Dict[str, str]] = None,
@@ -1561,7 +1601,8 @@ def get_cluster_service_info(cluster: Dict[str, Any]) -> List[str]:
 
 
 def output_members(cluster: Cluster, name: str, extended: bool = False,
-                   fmt: str = 'pretty', group: Optional[int] = None) -> None:
+                   fmt: str = 'pretty', group: Optional[int] = None,
+                   live_status: Optional[Dict[str, LiveMemberLSNs]] = None) -> None:
     """Print information about the Patroni cluster and its members.
 
     Information is printed to console through :func:`print_output`, and contains:
@@ -1594,6 +1635,7 @@ def output_members(cluster: Cluster, name: str, extended: bool = False,
         ``topology`` nor ``pretty``, then complementary information gathered through :func:`get_cluster_service_info` is
         not printed.
     :param group: filter which Citus group we should get members from. If ``None`` get from all groups.
+    :param live_status: optional mapping of member names to live LSN metrics gathered via the REST API.
     """
     rows: List[List[Any]] = []
     logging.debug(cluster)
@@ -1602,7 +1644,7 @@ def output_members(cluster: Cluster, name: str, extended: bool = False,
     columns = ['Cluster', 'Member', 'Host', 'Role', 'State', 'TL',
                'Receive LSN', 'Receive Lag', 'Replay LSN', 'Replay Lag']
 
-    clusters = {group or 0: cluster_as_json(cluster)}
+    clusters = {group or 0: cluster_as_json(cluster, live_status)}
 
     if is_citus_cluster():
         columns.insert(1, 'Group')
@@ -1730,9 +1772,9 @@ def members(ctx: click.Context, cluster_names: List[str], group: Optional[int], 
 
         for cluster_name in cluster_names:
             dcs = get_dcs(cluster_name, group)
-
             cluster = dcs.get_cluster()
-            output_members(cluster, cluster_name, extended, fmt, group)
+            live_status = fetch_live_status(cluster, ctx.obj.get('__list_live', False))
+            output_members(cluster, cluster_name, extended, fmt, group, live_status=live_status)
 
 
 @ctl.command('topology', help='Prints ASCII topology for given cluster')

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -1693,11 +1693,14 @@ def output_members(cluster: Cluster, name: str, extended: bool = False,
 @option_citus_group
 @click.option('--extended', '-e', help='Show some extra information', is_flag=True)
 @click.option('--timestamp', '-t', 'ts', help='Print timestamp', is_flag=True)
+@click.option('--live', is_flag=True,
+              help='Ask Patroni REST API for live replica LSN data (falls back to DCS if unavailable)')
 @option_format
 @option_watch
 @option_watchrefresh
-def members(cluster_names: List[str], group: Optional[int], fmt: str,
-            watch: Optional[int], w: bool, extended: bool, ts: bool) -> None:
+@click.pass_context
+def members(ctx: click.Context, cluster_names: List[str], group: Optional[int], fmt: str,
+            watch: Optional[int], w: bool, extended: bool, ts: bool, live: bool) -> None:
     """Process ``list`` command of ``patronictl`` utility.
 
     Print information about the Patroni cluster through :func:`output_members`.
@@ -1711,7 +1714,9 @@ def members(cluster_names: List[str], group: Optional[int], fmt: str,
     :param extended: if extended information should be printed. See ``extended`` argument of :func:`output_members` for
         more details.
     :param ts: if timestamp should be included in the output.
+    :param live: if ``True`` prefer live LSN data from the REST API when available.
     """
+    ctx.obj['__list_live'] = live
     config = _get_configuration()
     if not cluster_names:
         if 'scope' in config:

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -402,7 +402,8 @@ def get_dcs(scope: str, group: Optional[int]) -> AbstractDCS:
 
 
 def request_patroni(member: Member, method: str = 'GET',
-                    endpoint: Optional[str] = None, data: Optional[Any] = None) -> urllib3.response.HTTPResponse:
+                    endpoint: Optional[str] = None, data: Optional[Any] = None,
+                    **kwargs: Any) -> urllib3.response.HTTPResponse:
     """Perform a request to Patroni REST API.
 
     :param member: DCS member, used to get the base URL of its REST API server.
@@ -416,7 +417,7 @@ def request_patroni(member: Member, method: str = 'GET',
     request_executor = ctx.obj.get('__request_patroni')
     if not request_executor:
         request_executor = ctx.obj['__request_patroni'] = PatroniRequest(_get_configuration())
-    return request_executor(member, method, endpoint, data)
+    return request_executor(member, method, endpoint, data, **kwargs)
 
 
 def _parse_lsn_value(value: Any) -> Optional[int]:
@@ -437,6 +438,9 @@ def fetch_live_status(cluster: Cluster, live_requested: bool) -> Optional[Dict[s
     if not live_requested:
         return None
     for member in get_all_members_leader_first(cluster):
+        pool_logger = logging.getLogger('urllib3.connectionpool')
+        prev_level = pool_logger.level
+        pool_logger.setLevel(logging.ERROR)
         try:
             response = request_patroni(member, endpoint='cluster?live=1')
             if getattr(response, 'status', 0) >= 400:
@@ -456,6 +460,8 @@ def fetch_live_status(cluster: Cluster, live_requested: bool) -> Optional[Dict[s
                 return live_map
         except Exception as e:
             logging.debug('Failed to fetch live /cluster view from %s: %s', member.name, e)
+        finally:
+            pool_logger.setLevel(prev_level)
     return None
 
 
@@ -1602,7 +1608,8 @@ def get_cluster_service_info(cluster: Dict[str, Any]) -> List[str]:
 
 def output_members(cluster: Cluster, name: str, extended: bool = False,
                    fmt: str = 'pretty', group: Optional[int] = None,
-                   live_status: Optional[Dict[str, LiveMemberLSNs]] = None) -> None:
+                   live_status: Optional[Dict[str, LiveMemberLSNs]] = None,
+                   live_requested: bool = False) -> None:
     """Print information about the Patroni cluster and its members.
 
     Information is printed to console through :func:`print_output`, and contains:
@@ -1652,10 +1659,13 @@ def output_members(cluster: Cluster, name: str, extended: bool = False,
             clusters.update({g: cluster_as_json(c) for g, c in cluster.workers.items()})
 
     all_members = [m for c in clusters.values() for m in c['members'] if 'host' in m]
+    show_lsn_source = live_requested
 
     for c in ('Pending restart', 'Pending restart reason', 'Scheduled restart', 'Tags'):
         if extended or any(m.get(c.lower().replace(' ', '_')) for m in all_members):
             columns.append(c)
+    if show_lsn_source:
+        columns.append('LSN Source')
 
     # Show Host as 'host:port' if somebody is running on non-standard port or two nodes are running on the same host
     append_port = any('port' in m and m['port'] != 5432 for m in all_members) or\
@@ -1694,6 +1704,8 @@ def output_members(cluster: Cluster, name: str, extended: bool = False,
                           receive_lsn=receive_lsn, replay_lsn=replay_lsn,
                           pending_restart='*' if member.get('pending_restart') else '',
                           pending_restart_reason=restart_reason)
+            if show_lsn_source:
+                member['lsn_source'] = member.get('lsn_source', 'dcs')
 
             if append_port and member['host'] and member.get('port'):
                 member['host'] = ':'.join([member['host'], str(member['port'])])
@@ -1716,8 +1728,10 @@ def output_members(cluster: Cluster, name: str, extended: bool = False,
     title = f' {title}: {name}{title_details} '
     if fmt in ('pretty', 'topology'):
         columns[columns.index('Replay Lag')] = columns[columns.index('Receive Lag')] = 'Lag'
-    print_output(columns, rows,
-                 {'Group': 'r', 'Receive LSN': 'r', 'Replay LSN': 'r', 'Lag': 'r', 'TL': 'r'}, fmt, title)
+    alignment = {'Group': 'r', 'Receive LSN': 'r', 'Replay LSN': 'r', 'Lag': 'r', 'TL': 'r'}
+    if show_lsn_source:
+        alignment['LSN Source'] = 'l'
+    print_output(columns, rows, alignment, fmt, title)
 
     if fmt not in ('pretty', 'topology'):  # Omit service info when using machine-readable formats
         return
@@ -1773,8 +1787,10 @@ def members(ctx: click.Context, cluster_names: List[str], group: Optional[int], 
         for cluster_name in cluster_names:
             dcs = get_dcs(cluster_name, group)
             cluster = dcs.get_cluster()
-            live_status = fetch_live_status(cluster, ctx.obj.get('__list_live', False))
-            output_members(cluster, cluster_name, extended, fmt, group, live_status=live_status)
+            live_flag = ctx.obj.get('__list_live', False)
+            live_status = fetch_live_status(cluster, live_flag)
+            output_members(cluster, cluster_name, extended, fmt, group,
+                           live_status=live_status, live_requested=live_flag)
 
 
 @ctl.command('topology', help='Prints ASCII topology for given cluster')

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -68,7 +68,7 @@ from .exceptions import PatroniException
 from .postgresql.misc import parse_lsn, postgres_version_to_int, PostgresqlRole, PostgresqlState
 from .postgresql.mpp import get_mpp
 from .request import PatroniRequest
-from .utils import LiveMemberLSNs, cluster_as_json, patch_config, polling_loop
+from .utils import cluster_as_json, LiveMemberLSNs, patch_config, polling_loop
 from .version import __version__
 
 CONFIG_DIR_PATH = click.get_app_dir('patroni')

--- a/patroni/utils.py
+++ b/patroni/utils.py
@@ -25,7 +25,7 @@ import time
 from collections import OrderedDict
 from json import JSONDecoder
 from shlex import split
-from typing import Any, Callable, cast, Dict, Iterator, List, Optional, Tuple, Type, TYPE_CHECKING, Union
+from typing import Any, Callable, cast, Dict, Iterator, List, NamedTuple, Optional, Tuple, Type, TYPE_CHECKING, Union
 
 from dateutil import tz
 from urllib3.response import HTTPResponse
@@ -46,6 +46,14 @@ DEC_RE = re.compile(r'^[-+]?(0|[1-9][0-9]*)')
 HEX_RE = re.compile(r'^[-+]?0x[0-9a-fA-F]+')
 DBL_RE = re.compile(r'^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)?')
 WHITESPACE_RE = re.compile(r'[ \t\n\r]*', re.VERBOSE | re.MULTILINE | re.DOTALL)
+
+
+class LiveMemberLSNs(NamedTuple):
+    """Container for live WAL metrics collected outside of the DCS."""
+
+    lsn: Optional[int] = None
+    receive_lsn: Optional[int] = None
+    replay_lsn: Optional[int] = None
 
 
 def get_conversion_table(base_unit: str) -> Dict[str, Dict[str, Union[int, float]]]:
@@ -910,10 +918,13 @@ def iter_response_objects(response: HTTPResponse) -> Iterator[Dict[str, Any]]:
         prev = chunk[idx:]
 
 
-def cluster_as_json(cluster: 'Cluster') -> Dict[str, Any]:
+def cluster_as_json(cluster: 'Cluster', live_status: Optional[Dict[str, LiveMemberLSNs]] = None) -> Dict[str, Any]:
     """Get a JSON representation of *cluster*.
 
     :param cluster: the :class:`~patroni.dcs.Cluster` object to be parsed as JSON.
+    :param live_status: optional mapping of member names to live replication metrics (``lsn``, ``receive_lsn``,
+        ``replay_lsn``) gathered outside of the DCS. When provided, these values override the corresponding DCS
+        properties when rendering replica lag information.
 
     :returns: JSON representation of *cluster*.
 
@@ -953,6 +964,7 @@ def cluster_as_json(cluster: 'Cluster') -> Dict[str, Any]:
     config = global_config.from_cluster(cluster)
     leader_name = cluster.leader.name if cluster.leader else None
     cluster_lsn = cluster.status.last_lsn
+    live_status = live_status or {}
 
     ret: Dict[str, Any] = {'members': []}
     sync_role = 'quorum_standby' if config.is_quorum_commit_mode else 'sync_standby'
@@ -978,7 +990,9 @@ def cluster_as_json(cluster: 'Cluster') -> Dict[str, Any]:
             for location in ('receive_', 'replay_', ''):
                 lsn_type, lag_type = f'{location}lsn', f'{location}lag'
 
-                lsn = getattr(m, lsn_type)
+                live_entry = live_status.get(m.name)
+                live_lsn = getattr(live_entry, lsn_type) if live_entry else None
+                lsn = live_lsn if live_lsn is not None else getattr(m, lsn_type)
                 if not lsn:
                     member[lsn_type] = member[lag_type] = 'unknown'
                 elif cluster_lsn >= lsn:

--- a/patroni/utils.py
+++ b/patroni/utils.py
@@ -950,6 +950,7 @@ def cluster_as_json(cluster: 'Cluster', live_status: Optional[Dict[str, LiveMemb
             * ``lag``: replication lag for ``lsn``, if applicable;
             * ``receive_lag``: lag of the receive LSN;
             * ``replay_lag``: lag of the replay LSN;
+            * ``lsn_source``: ``live`` if LSN values were derived from a live poll, else ``dcs``;
 
         * ``pause``: ``True`` if cluster is in maintenance mode;
         * ``scheduled_switchover``: if a switchover has been scheduled, then it contains this entry with these keys:
@@ -969,6 +970,7 @@ def cluster_as_json(cluster: 'Cluster', live_status: Optional[Dict[str, LiveMemb
     ret: Dict[str, Any] = {'members': []}
     sync_role = 'quorum_standby' if config.is_quorum_commit_mode else 'sync_standby'
     for m in cluster.members:
+        live_entry = live_status.get(m.name)
         if m.name == leader_name:
             role = 'standby_leader' if config.is_standby_cluster else 'leader'
         elif config.is_synchronous_mode and cluster.sync.matches(m.name):
@@ -987,12 +989,14 @@ def cluster_as_json(cluster: 'Cluster', live_status: Optional[Dict[str, LiveMemb
         member.update({n: m.data[n] for n in optional_attributes if n in m.data})
 
         if m.name != leader_name:
+            member['lsn_source'] = 'live' if live_entry else 'dcs'
             for location in ('receive_', 'replay_', ''):
                 lsn_type, lag_type = f'{location}lsn', f'{location}lag'
 
-                live_entry = live_status.get(m.name)
-                live_lsn = getattr(live_entry, lsn_type) if live_entry else None
-                lsn = live_lsn if live_lsn is not None else getattr(m, lsn_type)
+                if live_entry:
+                    lsn = getattr(live_entry, lsn_type)
+                else:
+                    lsn = getattr(m, lsn_type)
                 if not lsn:
                     member[lsn_type] = member[lag_type] = 'unknown'
                 elif cluster_lsn >= lsn:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,13 +14,13 @@ from patroni.dcs import ClusterConfig, Member
 from patroni.exceptions import PostgresConnectionException
 from patroni.ha import _MemberStatus
 from patroni.postgresql.config import get_param_diff
-from patroni.postgresql.misc import PostgresqlRole, PostgresqlState
+from patroni.postgresql.misc import PostgresqlRole, PostgresqlState, format_lsn
 from patroni.psycopg import OperationalError
 from patroni.utils import LiveMemberLSNs, RetryFailedError, tzutc
 
 from . import MockConnect, psycopg_connect
 from .test_etcd import socket_getaddrinfo
-from .test_ha import get_cluster_initialized_without_leader
+from .test_ha import get_cluster_initialized_without_leader, get_cluster_initialized_with_only_leader
 
 future_restart_time = datetime.datetime.now(tzutc) + datetime.timedelta(days=5)
 postmaster_start_time = datetime.datetime.now(tzutc)
@@ -401,8 +401,13 @@ class TestRestApiHandler(unittest.TestCase):
     def test_do_GET_cluster(self, mock_dcs):
         mock_dcs.get_cluster.return_value = get_cluster_initialized_without_leader()
         mock_dcs.get_cluster.return_value.members[1].data['xlog_location'] = 11
-        self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'GET /cluster'))
-        self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'GET /cluster?live=1'))
+        with patch.object(RestApiHandler, 'get_live_member_lsns') as live_mock, \
+                patch.object(RestApiHandler, '_write_json_response') as responder:
+            self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'GET /cluster'))
+            live_mock.assert_not_called()
+        payload = responder.call_args[0][1]
+        replica = next(m for m in payload['members'] if m['role'] == 'replica')
+        self.assertEqual(replica['lsn_source'], 'dcs')
 
     def _make_handler(self):
         handler = RestApiHandler.__new__(RestApiHandler)  # type: ignore
@@ -433,7 +438,7 @@ class TestRestApiHandler(unittest.TestCase):
         with patch.object(handler.server.patroni.ha, 'fetch_nodes_statuses', Mock(return_value=[status])):
             with patch.object(handler.server.patroni.postgresql, 'name', cluster.leader.name):
                 live_map = handler.get_live_member_lsns(cluster)
-        self.assertEqual(live_map[remote.name], LiveMemberLSNs())
+        self.assertNotIn(remote.name, live_map)
 
     def test_get_live_member_lsns_local_failure(self):
         handler = self._make_handler()
@@ -459,10 +464,41 @@ class TestRestApiHandler(unittest.TestCase):
         status = handler._status_to_live_lsn({})
         self.assertEqual(status, LiveMemberLSNs())
 
+    def test_status_to_live_lsn_replay_fallback(self):
+        handler = self._make_handler()
+        status = handler._status_to_live_lsn({'xlog': {'replayed_location': 123, 'received_location': 120}})
+        self.assertEqual(status.lsn, 123)
+        self.assertEqual(status.replay_lsn, 123)
+        self.assertEqual(status.receive_lsn, 120)
     @patch.object(MockPatroni, 'dcs')
     def test_do_GET_history(self, mock_dcs):
         mock_dcs.cluster = get_cluster_initialized_without_leader()
         self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'GET /history'))
+
+    @patch.object(MockPatroni, 'dcs')
+    def test_do_GET_cluster_live_skips_single_member(self, mock_dcs):
+        mock_dcs.get_cluster.return_value = get_cluster_initialized_with_only_leader()
+        with patch.object(RestApiHandler, 'get_live_member_lsns') as live_mock, \
+                patch.object(RestApiHandler, '_write_json_response') as responder:
+            MockRestApiServer(RestApiHandler, 'GET /cluster?live=1')
+        live_mock.assert_not_called()
+        payload = responder.call_args[0][1]
+        self.assertNotIn('lag_source', payload)
+
+    @patch.object(MockPatroni, 'dcs')
+    def test_do_GET_cluster_live_uses_helper(self, mock_dcs):
+        cluster = get_cluster_initialized_without_leader(leader=True)
+        mock_dcs.get_cluster.return_value = cluster
+        live_map = {'other': LiveMemberLSNs(lsn=20, receive_lsn=18, replay_lsn=16)}
+        live_mock = Mock(return_value=live_map)
+        with patch.object(RestApiHandler, 'get_live_member_lsns', live_mock), \
+                patch.object(RestApiHandler, '_write_json_response') as responder:
+            MockRestApiServer(RestApiHandler, 'GET /cluster?live=1')
+        live_mock.assert_called_once()
+        payload = responder.call_args[0][1]
+        replica = next(m for m in payload['members'] if m['name'] == 'other')
+        self.assertEqual(replica['lsn'], format_lsn(20))
+        self.assertEqual(replica['lsn_source'], 'live')
 
     @patch.object(MockPatroni, 'dcs')
     def test_do_GET_config(self, mock_dcs):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,13 +14,13 @@ from patroni.dcs import ClusterConfig, Member
 from patroni.exceptions import PostgresConnectionException
 from patroni.ha import _MemberStatus
 from patroni.postgresql.config import get_param_diff
-from patroni.postgresql.misc import PostgresqlRole, PostgresqlState, format_lsn
+from patroni.postgresql.misc import format_lsn, PostgresqlRole, PostgresqlState
 from patroni.psycopg import OperationalError
 from patroni.utils import LiveMemberLSNs, RetryFailedError, tzutc
 
 from . import MockConnect, psycopg_connect
 from .test_etcd import socket_getaddrinfo
-from .test_ha import get_cluster_initialized_without_leader, get_cluster_initialized_with_only_leader
+from .test_ha import get_cluster_initialized_with_only_leader, get_cluster_initialized_without_leader
 
 future_restart_time = datetime.datetime.now(tzutc) + datetime.timedelta(days=5)
 postmaster_start_time = datetime.datetime.now(tzutc)
@@ -470,6 +470,7 @@ class TestRestApiHandler(unittest.TestCase):
         self.assertEqual(status.lsn, 123)
         self.assertEqual(status.replay_lsn, 123)
         self.assertEqual(status.receive_lsn, 120)
+
     @patch.object(MockPatroni, 'dcs')
     def test_do_GET_history(self, mock_dcs):
         mock_dcs.cluster = get_cluster_initialized_without_leader()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,7 +16,7 @@ from patroni.ha import _MemberStatus
 from patroni.postgresql.config import get_param_diff
 from patroni.postgresql.misc import PostgresqlRole, PostgresqlState
 from patroni.psycopg import OperationalError
-from patroni.utils import RetryFailedError, tzutc
+from patroni.utils import LiveMemberLSNs, RetryFailedError, tzutc
 
 from . import MockConnect, psycopg_connect
 from .test_etcd import socket_getaddrinfo
@@ -403,6 +403,61 @@ class TestRestApiHandler(unittest.TestCase):
         mock_dcs.get_cluster.return_value.members[1].data['xlog_location'] = 11
         self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'GET /cluster'))
         self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'GET /cluster?live=1'))
+
+    def _make_handler(self):
+        handler = RestApiHandler.__new__(RestApiHandler)  # type: ignore
+        handler.server = Mock()
+        handler.server.patroni = MockPatroni()
+        return handler
+
+    def test_get_live_member_lsns_success(self):
+        handler = self._make_handler()
+        cluster = get_cluster_initialized_without_leader(leader=True)
+        remote = next(m for m in cluster.members if m.name != cluster.leader.name)
+        handler.get_postgresql_status = Mock(return_value={'xlog': {'location': 30}})
+        status = _MemberStatus(remote, True, True, 0, {'xlog': {'received_location': 12, 'replayed_location': 11}})
+        with patch.object(handler.server.patroni.ha, 'fetch_nodes_statuses', Mock(return_value=[status])):
+            with patch.object(handler.server.patroni.postgresql, 'name', cluster.leader.name):
+                live_map = handler.get_live_member_lsns(cluster)
+        self.assertIn(cluster.leader.name, live_map)
+        self.assertEqual(live_map[cluster.leader.name].lsn, 30)
+        self.assertEqual(live_map[remote.name].receive_lsn, 12)
+        self.assertEqual(live_map[remote.name].replay_lsn, 11)
+
+    def test_get_live_member_lsns_timeout(self):
+        handler = self._make_handler()
+        cluster = get_cluster_initialized_without_leader(leader=True)
+        remote = next(m for m in cluster.members if m.name != cluster.leader.name)
+        handler.get_postgresql_status = Mock(return_value={'xlog': {'location': 20}})
+        status = _MemberStatus(remote, False, None, 0, {})
+        with patch.object(handler.server.patroni.ha, 'fetch_nodes_statuses', Mock(return_value=[status])):
+            with patch.object(handler.server.patroni.postgresql, 'name', cluster.leader.name):
+                live_map = handler.get_live_member_lsns(cluster)
+        self.assertEqual(live_map[remote.name], LiveMemberLSNs())
+
+    def test_get_live_member_lsns_local_failure(self):
+        handler = self._make_handler()
+        cluster = get_cluster_initialized_without_leader(leader=True)
+        handler.get_postgresql_status = Mock(side_effect=Exception("boom"))
+        with patch.object(handler.server.patroni.ha, 'fetch_nodes_statuses', Mock(return_value=[])):
+            with patch.object(handler.server.patroni.postgresql, 'name', cluster.leader.name):
+                live_map = handler.get_live_member_lsns(cluster)
+        self.assertNotIn(cluster.leader.name, live_map)
+
+    def test_get_live_member_lsns_fetch_exception(self):
+        handler = self._make_handler()
+        cluster = get_cluster_initialized_without_leader(leader=True)
+        handler.get_postgresql_status = Mock(return_value={'xlog': {'location': 15}})
+        fetch_mock = Mock(side_effect=Exception("network"))
+        with patch.object(handler.server.patroni.ha, 'fetch_nodes_statuses', fetch_mock):
+            with patch.object(handler.server.patroni.postgresql, 'name', cluster.leader.name):
+                live_map = handler.get_live_member_lsns(cluster)
+        self.assertEqual(live_map[cluster.leader.name].lsn, 15)
+
+    def test_status_to_live_lsn_missing_fields(self):
+        handler = self._make_handler()
+        status = handler._status_to_live_lsn({})
+        self.assertEqual(status, LiveMemberLSNs())
 
     @patch.object(MockPatroni, 'dcs')
     def test_do_GET_history(self, mock_dcs):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -402,6 +402,7 @@ class TestRestApiHandler(unittest.TestCase):
         mock_dcs.get_cluster.return_value = get_cluster_initialized_without_leader()
         mock_dcs.get_cluster.return_value.members[1].data['xlog_location'] = 11
         self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'GET /cluster'))
+        self.assertIsNotNone(MockRestApiServer(RestApiHandler, 'GET /cluster?live=1'))
 
     @patch.object(MockPatroni, 'dcs')
     def test_do_GET_history(self, mock_dcs):

--- a/tests/test_ctl.py
+++ b/tests/test_ctl.py
@@ -32,7 +32,7 @@ from patroni.dcs import Cluster, Failover
 from patroni.postgresql.config import get_param_diff
 from patroni.postgresql.mpp import get_mpp
 from patroni.psycopg import OperationalError
-from patroni.utils import tzutc
+from patroni.utils import LiveMemberLSNs, tzutc
 
 from . import MockConnect, MockCursor, MockResponse, psycopg_connect
 from .test_etcd import etcd_read, socket_getaddrinfo
@@ -555,6 +555,32 @@ class TestCtl(unittest.TestCase):
         _, kwargs = output.call_args
         self.assertIn('live_status', kwargs)
         self.assertTrue(kwargs['live_status'])
+        self.assertTrue(kwargs.get('live_requested'))
+
+    def test_output_members_shows_lsn_source(self):
+        cluster = get_cluster_initialized_with_leader()
+        live_map = {'other': LiveMemberLSNs(lsn=5, receive_lsn=4, replay_lsn=3)}
+        with click.Context(click.Command('list')) as ctx:
+            ctx.obj = {'__config': {}, '__mpp': get_mpp({})}
+            with patch('click.echo') as mock_echo:
+                output_members(cluster, name='alpha', fmt='tsv', live_status=live_map, live_requested=True)
+        header = mock_echo.call_args_list[0][0][0]
+        self.assertIn('LSN Source', header)
+        replica_row = next(call[0][0] for call in mock_echo.call_args_list if 'other' in call[0][0])
+        self.assertIn('live', replica_row)
+        leader_row = next(call[0][0] for call in mock_echo.call_args_list if '\tleader\t' in call[0][0])
+        self.assertIn('dcs', leader_row)
+
+    def test_output_members_live_requested_without_data(self):
+        cluster = get_cluster_initialized_with_leader()
+        with click.Context(click.Command('list')) as ctx:
+            ctx.obj = {'__config': {}, '__mpp': get_mpp({})}
+            with patch('click.echo') as mock_echo:
+                output_members(cluster, name='alpha', fmt='tsv', live_requested=True)
+        header = mock_echo.call_args_list[0][0][0]
+        self.assertIn('LSN Source', header)
+        row = mock_echo.call_args_list[1][0][0]
+        self.assertIn('dcs', row)
 
     def test_list_standby_cluster(self):
         cluster = get_cluster_initialized_without_leader(leader=True, sync=('leader', 'other'))

--- a/tests/test_ctl.py
+++ b/tests/test_ctl.py
@@ -532,6 +532,17 @@ class TestCtl(unittest.TestCase):
         assert '2100' in result.output
         assert 'Scheduled restart' in result.output
 
+    def test_list_live_flag(self):
+        captured = []
+
+        def _capture(*args, **kwargs):
+            captured.append(click.get_current_context().obj.get('__list_live'))
+
+        with patch('patroni.ctl.output_members', side_effect=_capture):
+            result = self.runner.invoke(ctl, ['list', '--live'])
+        self.assertEqual(result.exit_code, 0)
+        self.assertTrue(captured and all(captured))
+
     def test_list_standby_cluster(self):
         cluster = get_cluster_initialized_without_leader(leader=True, sync=('leader', 'other'))
         cluster.config.data.update(synchronous_mode=True, standby_cluster={'port': 5433})

--- a/tests/test_ctl.py
+++ b/tests/test_ctl.py
@@ -1,3 +1,4 @@
+import json
 import os
 import unittest
 
@@ -542,6 +543,18 @@ class TestCtl(unittest.TestCase):
             result = self.runner.invoke(ctl, ['list', '--live'])
         self.assertEqual(result.exit_code, 0)
         self.assertTrue(captured and all(captured))
+
+    def test_list_live_fetches_rest(self):
+        payload = {'members': [{'name': 'other', 'lsn': '0/10', 'receive_lsn': '0/8', 'replay_lsn': '0/8'}]}
+        response = Mock(status=200, data=json.dumps(payload).encode('utf-8'))
+        with patch('patroni.ctl.request_patroni', Mock(return_value=response)) as req, \
+                patch('patroni.ctl.output_members') as output:
+            result = self.runner.invoke(ctl, ['list', '--live'])
+        self.assertEqual(result.exit_code, 0)
+        req.assert_called()
+        _, kwargs = output.call_args
+        self.assertIn('live_status', kwargs)
+        self.assertTrue(kwargs['live_status'])
 
     def test_list_standby_cluster(self):
         cluster = get_cluster_initialized_without_leader(leader=True, sync=('leader', 'other'))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,8 +5,9 @@ from unittest.mock import Mock, patch
 
 from patroni.exceptions import PatroniException
 from patroni.postgresql.misc import format_lsn
-from patroni.utils import LiveMemberLSNs, apply_keepalive_limit, cluster_as_json, enable_keepalive, get_major_version, \
-    get_postgres_version, polling_loop, Retry, RetryFailedError, unquote, validate_directory
+from patroni.utils import apply_keepalive_limit, cluster_as_json, enable_keepalive, get_major_version, \
+    get_postgres_version, LiveMemberLSNs, polling_loop, Retry, RetryFailedError, unquote, validate_directory
+
 from .test_ha import get_cluster_initialized_without_leader
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,8 +4,10 @@ import unittest
 from unittest.mock import Mock, patch
 
 from patroni.exceptions import PatroniException
-from patroni.utils import apply_keepalive_limit, enable_keepalive, get_major_version, \
+from patroni.postgresql.misc import format_lsn
+from patroni.utils import LiveMemberLSNs, apply_keepalive_limit, cluster_as_json, enable_keepalive, get_major_version, \
     get_postgres_version, polling_loop, Retry, RetryFailedError, unquote, validate_directory
+from .test_ha import get_cluster_initialized_without_leader
 
 
 class TestUtils(unittest.TestCase):
@@ -161,3 +163,28 @@ class TestRetrySleeper(unittest.TestCase):
         retry = Retry(sleep_func=_sleep)
         rcopy = retry.copy()
         self.assertTrue(rcopy.sleep_func is _sleep)
+
+
+class TestClusterAsJson(unittest.TestCase):
+
+    @staticmethod
+    def _cluster_with_replica_metrics():
+        cluster = get_cluster_initialized_without_leader()
+        replica = next(m for m in cluster.members if m.name == 'other')
+        replica.data.update({'xlog_location': 6, 'receive_lsn': 5, 'replay_lsn': 4})
+        return cluster, replica.name
+
+    def test_live_none_matches_default(self):
+        cluster, _ = self._cluster_with_replica_metrics()
+        self.assertEqual(cluster_as_json(cluster), cluster_as_json(cluster, None))
+
+    def test_live_values_override(self):
+        cluster, replica_name = self._cluster_with_replica_metrics()
+        live_metrics = {replica_name: LiveMemberLSNs(lsn=8, receive_lsn=7, replay_lsn=6)}
+        response = cluster_as_json(cluster, live_metrics)
+
+        replica = next(m for m in response['members'] if m['name'] == replica_name)
+        self.assertEqual(replica['lsn'], format_lsn(8))
+        self.assertEqual(replica['lag'], cluster.status.last_lsn - 8)
+        self.assertEqual(replica['receive_lsn'], format_lsn(7))
+        self.assertEqual(replica['receive_lag'], cluster.status.last_lsn - 7)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -188,3 +188,10 @@ class TestClusterAsJson(unittest.TestCase):
         self.assertEqual(replica['lag'], cluster.status.last_lsn - 8)
         self.assertEqual(replica['receive_lsn'], format_lsn(7))
         self.assertEqual(replica['receive_lag'], cluster.status.last_lsn - 7)
+        self.assertEqual(replica['lsn_source'], 'live')
+
+    def test_dcs_sources_when_no_live(self):
+        cluster, replica_name = self._cluster_with_replica_metrics()
+        response = cluster_as_json(cluster)
+        replica = next(m for m in response['members'] if m['name'] == replica_name)
+        self.assertEqual(replica['lsn_source'], 'dcs')


### PR DESCRIPTION
Calculate LSNs from live members instead of using DCS infomation.

This makes /cluster?live=1 reach out to live members directly instead of using LSNs and lags stored in the DCS. The use case is to get up-to-date lag information, for instance, if DCS is updated rarely. The practical use case is this being a step to decoupling member status update (such as xlog position) from the critical information necessary perform switchover and failover decisions (is postgres running, role, etc). We can have different update intervals to those once we can get lags and wal positions live, in case they are not up-to-date.

patronictl status --lve option is added to get live lag information via patronictl