### PR TITLE
Throttle xlog-only member updates via xlog_cache_ttl 

### DIFF
--- a/docs/ENVIRONMENT.rst
+++ b/docs/ENVIRONMENT.rst
@@ -11,6 +11,8 @@ Global/Universal
 -  **PATRONI\_NAME**: name of the node where the current instance of Patroni is running. Must be unique for the cluster.
 -  **PATRONI\_NAMESPACE**: path within the configuration store where Patroni will keep information about the cluster. Default value: "/service"
 -  **PATRONI\_SCOPE**: cluster name
+-  **PATRONI\_XLOG\_CACHE\_TTL**: amount of seconds Patroni may cache updates that only change ``xlog_location`` before
+   writing them to the DCS. Must be a non-negative integer.
 
 Log
 ---

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -89,6 +89,7 @@ Why is the information about one of my Patroni members not up-to-date in the out
 
     By default, that information is updated by Patroni roughly every ``loop_wait`` seconds.
     In other words, even if everything is normally functional you may still see a "delay" of up to ``loop_wait`` seconds in the information stored in the DCS.
+    When :ref:`xlog_cache_ttl <patroni_configuration>` is configured with a positive value, Patroni will additionally delay DCS writes that only change ``xlog_location`` for up to that amount of time.
 
     Be aware that that is not a rule, though. Some operations performed by Patroni cause it to immediately update the DCS information.
 

--- a/docs/patroni_configuration.rst
+++ b/docs/patroni_configuration.rst
@@ -137,6 +137,7 @@ Also the following Patroni configuration options **can be changed only dynamical
 - **ttl**: 30
 - **loop_wait**: 10
 - **retry_timeouts**: 10
+- **xlog_cache_ttl**: 0
 - **maximum_lag_on_failover**: 1048576
 - **max_timelines_history**: 0
 - **check_timeline**: false

--- a/docs/patronictl.rst
+++ b/docs/patronictl.rst
@@ -723,6 +723,15 @@ Besides that, the following information may be included in the output:
 
         Only shown if a Citus cluster.
 
+``Last modified``
+    Timestamp (in ISO 8601 format) of the last successful update this member wrote to the DCS. Use it to determine how
+    fresh the rest of the member information is.
+
+    .. note::
+        Shown as a member attribute.
+
+        Only shown if extended output is enabled.
+
 ``Pending restart``
     ``*`` indicates that the node needs a restart for some Postgres configuration to take effect. An empty value indicates the node does not require a restart.
 
@@ -791,7 +800,8 @@ Parameters
 ``-e`` / ``--extended``
     Show extended information.
 
-    Force showing ``Pending restart``, ``Scheduled restart`` and ``Tags`` attributes, even if their value is empty.
+    Force showing ``Pending restart``, ``Scheduled restart`` and ``Tags`` attributes, even if their value is empty. Also
+    enables the ``Last modified`` attribute.
 
     .. note::
         Only applies to ``pretty`` and ``tsv`` output formats.
@@ -842,13 +852,13 @@ Show information about the cluster in pretty format with extended columns:
 .. code:: bash
 
     $ patronictl -c postgres0.yml list batman -e
-    + Cluster: batman (7277694203142172922) -+-----------+----+-------------+-----+------------+-----+-----------------+------------------------+-------------------+------+
-    | Member      | Host           | Role    | State     | TL | Receive LSN | Lag | Replay LSN | Lag | Pending restart | Pending restart reason | Scheduled restart | Tags |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+-----------------+------------------------+-------------------+------+
-    | postgresql0 | 127.0.0.1:5432 | Leader  | running   |  5 |             |     |            |     |                 |                        |                   |      |
-    | postgresql1 | 127.0.0.1:5433 | Replica | streaming |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |                 |                        |                   |      |
-    | postgresql2 | 127.0.0.1:5434 | Replica | streaming |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 |                 |                        |                   |      |
-    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+-----------------+------------------------+-------------------+------+
+    + Cluster: batman (7277694203142172922) -+-----------+----+-------------+-----+------------+-----+----------------------+-----------------+------------------------+-------------------+------+
+    | Member      | Host           | Role    | State     | TL | Receive LSN | Lag | Replay LSN | Lag | Last modified        | Pending restart | Pending restart reason | Scheduled restart | Tags |
+    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+----------------------+-----------------+------------------------+-------------------+------+
+    | postgresql0 | 127.0.0.1:5432 | Leader  | running   |  5 |             |     |            |     | 2024-09-09T12:00:00Z |                 |                        |                   |      |
+    | postgresql1 | 127.0.0.1:5433 | Replica | streaming |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 | 2024-09-09T12:00:05Z |                 |                        |                   |      |
+    | postgresql2 | 127.0.0.1:5434 | Replica | streaming |  5 |   0/40004E8 |   0 |  0/40004E8 |   0 | 2024-09-09T12:00:05Z |                 |                        |                   |      |
+    +-------------+----------------+---------+-----------+----+-------------+-----+------------+-----+----------------------+-----------------+------------------------+-------------------+------+
 
 Show information about the cluster in YAML format, with timestamp of execution:
 

--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -440,7 +440,8 @@ Cluster status endpoints
           "timeline": 5,
           "tags": {
             "clonefrom": true
-          }
+          },
+          "last_modified": "2024-09-09T12:00:00+00:00"
         },
         {
           "name": "patroni2",
@@ -458,7 +459,8 @@ Cluster status endpoints
           "replay_lag": 0,
           "replay_lsn": "0/4000060",
           "lag": 0,
-          "lsn": "0/4000060"
+          "lsn": "0/4000060",
+          "last_modified": "2024-09-09T12:00:05+00:00"
         }
       ],
       "scope": "demo",
@@ -471,6 +473,10 @@ Cluster status endpoints
 
 
 - The ``GET /history`` endpoint provides a view on the history of cluster switchovers/failovers. The format is very similar to the content of history files in the ``pg_wal`` directory. The only difference is the timestamp field showing when the new timeline was created.
+
+Each member entry in the ``members`` array also contains a ``last_modified`` attribute indicating when that node last
+successfully updated its information in the DCS. It is useful for identifying stale ``xlog_location`` values when
+``xlog_cache_ttl`` defers WAL-only writes.
 
 .. code-block:: bash
 

--- a/patroni/config.py
+++ b/patroni/config.py
@@ -88,6 +88,7 @@ class Config(object):
     __CACHE_FILENAME = 'patroni.dynamic.json'
     __DEFAULT_CONFIG: Dict[str, Any] = {
         'ttl': 30, 'loop_wait': 10, 'retry_timeout': 10,
+        'xlog_cache_ttl': 0,
         'standby_cluster': {
             'create_replica_methods': '',
             'host': '',

--- a/patroni/config.py
+++ b/patroni/config.py
@@ -493,6 +493,12 @@ class Config(object):
             if value:
                 ret[param] = value
 
+        value = _popenv('xlog_cache_ttl')
+        if value:
+            value = parse_int(value)
+            if value is not None:
+                ret['xlog_cache_ttl'] = value
+
         def _fix_log_env(name: str, oldname: str) -> None:
             """Normalize a log related environment variable.
 

--- a/patroni/ctl.py
+++ b/patroni/ctl.py
@@ -1611,6 +1611,9 @@ def output_members(cluster: Cluster, name: str, extended: bool = False,
 
     all_members = [m for c in clusters.values() for m in c['members'] if 'host' in m]
 
+    if extended:
+        columns.append('Last modified')
+
     for c in ('Pending restart', 'Pending restart reason', 'Scheduled restart', 'Tags'):
         if extended or any(m.get(c.lower().replace(' ', '_')) for m in all_members):
             columns.append(c)

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -511,6 +511,7 @@ class Ha(object):
             if self._should_skip_xlog_update(data):
                 return True
 
+            data['last_modified'] = datetime.datetime.now(tzutc).isoformat()
             ret = self.dcs.touch_member(data)
             if ret:
                 self._last_member_data = data.copy()
@@ -540,6 +541,7 @@ class Ha(object):
 
         keys = set(self._last_member_data.keys()) | set(data.keys())
         keys.discard('xlog_location')
+        keys.discard('last_modified')
         for key in keys:
             if self._last_member_data.get(key) != data.get(key):
                 return False

--- a/patroni/ha.py
+++ b/patroni/ha.py
@@ -511,11 +511,14 @@ class Ha(object):
             if self._should_skip_xlog_update(data):
                 return True
 
-            data['last_modified'] = datetime.datetime.now(tzutc).isoformat()
+            timestamp = time.time()
+            if timestamp <= self._last_member_data_timestamp:
+                timestamp = self._last_member_data_timestamp + 1e-6
+            data['last_modified'] = datetime.datetime.fromtimestamp(timestamp, tzutc).isoformat()
             ret = self.dcs.touch_member(data)
             if ret:
                 self._last_member_data = data.copy()
-                self._last_member_data_timestamp = time.time()
+                self._last_member_data_timestamp = timestamp
                 new_state = (data['state'], data['role'])
                 if self._last_state != new_state and new_state == (PostgresqlState.RUNNING, PostgresqlRole.PRIMARY):
                     self.notify_mpp_coordinator('after_promote')

--- a/patroni/utils.py
+++ b/patroni/utils.py
@@ -931,6 +931,7 @@ def cluster_as_json(cluster: 'Cluster') -> Dict[str, Any]:
             * ``pending_restart``: ``True`` if PostgreSQL is pending to be restarted;
             * ``scheduled_restart``: scheduled restart timestamp, if any;
             * ``tags``: any tags that were set for this member;
+            * ``last_modified``: ISO 8601 timestamp when the member last updated its DCS entry;
             * ``lsn``: current WAL position. See :meth:`Postgresql._wal_position`
             * ``receive_lsn``: receive LSN (``pg_catalog.pg_last_(xlog|wal)_receive_(location|lsn)()``),
                 if applicable;
@@ -971,7 +972,14 @@ def cluster_as_json(cluster: 'Cluster') -> Dict[str, Any]:
             member['host'] = conn_kwargs['host']
             if conn_kwargs.get('port'):
                 member['port'] = int(conn_kwargs['port'])
-        optional_attributes = ('timeline', 'pending_restart', 'pending_restart_reason', 'scheduled_restart', 'tags')
+        optional_attributes = (
+            'timeline',
+            'pending_restart',
+            'pending_restart_reason',
+            'scheduled_restart',
+            'tags',
+            'last_modified'
+        )
         member.update({n: m.data[n] for n in optional_attributes if n in m.data})
 
         if m.name != leader_name:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -79,10 +79,12 @@ class TestConfig(unittest.TestCase):
             'PATRONI_REPLICATION_PASSWORD': 'rep-pass',
             'PATRONI_admin_PASSWORD': 'admin',
             'PATRONI_admin_OPTIONS': 'createrole,createdb',
-            'PATRONI_POSTGRESQL_BIN_POSTGRES': 'sergtsop'
+            'PATRONI_POSTGRESQL_BIN_POSTGRES': 'sergtsop',
+            'PATRONI_XLOG_CACHE_TTL': '60'
         })
         config = Config('postgres0.yml')
         self.assertEqual(config.local_configuration['log']['mode'], 0o123)
+        self.assertEqual(config.local_configuration['xlog_cache_ttl'], 60)
         with patch.object(Config, '_load_config_file', Mock(return_value={'restapi': {}})):
             with patch.object(Config, '_build_effective_configuration', Mock(side_effect=Exception)):
                 config.reload_local_configuration()

--- a/tests/test_ctl.py
+++ b/tests/test_ctl.py
@@ -497,6 +497,7 @@ class TestCtl(unittest.TestCase):
     def test_members(self):
         result = self.runner.invoke(ctl, ['list'])
         assert '127.0.0.1' in result.output
+        assert 'Last modified' not in result.output
         assert result.exit_code == 0
         assert 'Citus cluster: alpha -' in result.output
 
@@ -531,6 +532,7 @@ class TestCtl(unittest.TestCase):
         result = self.runner.invoke(ctl, ['list', 'dummy', '--extended', '--timestamp'])
         assert '2100' in result.output
         assert 'Scheduled restart' in result.output
+        assert 'Last modified' in result.output
 
     def test_list_standby_cluster(self):
         cluster = get_cluster_initialized_without_leader(leader=True, sync=('leader', 'other'))

--- a/tests/test_ha.py
+++ b/tests/test_ha.py
@@ -258,6 +258,7 @@ class TestHa(PostgresInit):
         self.ha.dcs.touch_member = true
         self.ha.touch_member()
 
+    @patch('patroni.postgresql.Postgresql.replication_state', Mock(return_value='streaming'))
     @patch.object(Postgresql, 'received_timeline', Mock(return_value=None))
     def test_touch_member_xlog_cache_ttl(self):
         self.ha.patroni.config._Config__effective_configuration['xlog_cache_ttl'] = 60
@@ -281,12 +282,15 @@ class TestHa(PostgresInit):
         self.assertEqual(self.ha.dcs.touch_member.call_count, 1)
         self.assertEqual(self.ha._last_member_data['last_modified'], first_last_modified)
 
-        self.ha._last_member_data_timestamp -= 100
         newest_position = (0, 30, 0, 0, 0)
         self.p.timeline_wal_position = Mock(return_value=newest_position)
-        self.assertTrue(self.ha.touch_member())
-        self.assertEqual(self.ha.dcs.touch_member.call_count, 2)
-        second_last_modified = self.ha.dcs.touch_member.call_args[0][0]['last_modified']
+        cached_timestamp = self.ha._last_member_data_timestamp
+        # mock time to advance past the xlog ttl
+        mock_time = [cached_timestamp + 120.0] * 3
+        with patch('patroni.ha.time.time', side_effect=mock_time):
+            self.assertTrue(self.ha.touch_member())
+            self.assertEqual(self.ha.dcs.touch_member.call_count, 2)
+            second_last_modified = self.ha.dcs.touch_member.call_args[0][0]['last_modified']
         self.assertNotEqual(first_last_modified, second_last_modified)
 
     def test_is_leader(self):


### PR DESCRIPTION
introduce xlog_cache_ttl (default 0) to defer DCS writes that only change xlog_location while ensuring any other member-info changes still flush immediately with the current WAL position.